### PR TITLE
Update TetrisItemData_AutoCalculator.lua

### DIFF
--- a/Contents/mods/InventoryTetris/42.0/media/lua/client/InventoryTetris/Data/TetrisItemData_AutoCalculator.lua
+++ b/Contents/mods/InventoryTetris/42.0/media/lua/client/InventoryTetris/Data/TetrisItemData_AutoCalculator.lua
@@ -3,6 +3,31 @@ TetrisItemData = TetrisItemData or {} -- Partial class
 local SQUISH_FACTOR = 3
 local FLOAT_CORRECTION = 0.001
 
+-- Whole numbers only
+local ITEM_SIZE_MULT = 2 -- int
+
+-- Category specific toggles for size multiplier
+local SIZE_MULT_TOGGLE_TABLE = {
+    ["Magazines"] = true,
+    ["Ammo"] = true,
+    ["RangedWeapons"] = true,
+    ["MeleeWeapons"] = true,
+    ["Clothing"] = true,
+    ["WeightBased"] = true,
+    ["Entertainment"] = true,
+    ["Books"] = true,
+    ["Seeds"] = true,
+}
+
+-- Type safety checks
+if (type(ITEM_SIZE_MULT) ~= "number") then
+    ITEM_SIZE_MULT = 1
+end
+if (math.type(ITEM_SIZE_MULT) ~= "integer" or ITEM_SIZE_MULT <= 0) then
+    ITEM_SIZE_MULT = math.modf(math.abs(ITEM_SIZE_MULT))
+end
+
+
 function TetrisItemData._autoCalculateItemInfo(item, isSquished)
     local data = {}
 
@@ -15,8 +40,8 @@ function TetrisItemData._autoCalculateItemInfo(item, isSquished)
         local category = TetrisItemCategory.getCategory(item)
         data.maxStackSize = TetrisItemData._calculateItemStackability(item, category)
         data.width, data.height = TetrisItemData._calculateItemSize(item, category)
-        if data.width > 20 then data.width = 20 end
-        if data.height > 24 then data.height = 24 end
+        if data.width > (10 * ITEM_SIZE_MULT) then data.width = (10 * ITEM_SIZE_MULT) end
+        if data.height > (12 * ITEM_SIZE_MULT) then data.height = (12 * ITEM_SIZE_MULT) end
     end
 
     if isSquished then
@@ -38,90 +63,120 @@ function TetrisItemData._calculateItemSize(item, category)
 end
 
 function TetrisItemData._calculateItemSizeMagazine(item)
-    local width = 2
-    local height = 2
+    local width = 1
+    local height = 1
 
     local maxAmmo = item:getMaxAmmo()
     if maxAmmo > 15 then
-        height = 4
-        width = 2
+        height = 2
+        width = 1
     end
     if maxAmmo > 30 then
-        height = 6
-        width = 2
+        height = 3
+        width = 1
     end
     if maxAmmo > 45 then
-        height = 4
-        width = 4
+        height = 2
+        width = 2
+    end
+
+    if (SIZE_MULT_TOGGLE_TABLE["Magazines"] == true) then
+        width = width * ITEM_SIZE_MULT
+        height = height * ITEM_SIZE_MULT
+    end
+
+
+    return width, height
+end
+
+function TetrisItemData._calculateAmmoSize(item)
+    local width = 1
+    local height = 1
+
+    local weight = item:getActualWeight()
+
+    if (SIZE_MULT_TOGGLE_TABLE["Ammo"] == true) then
+        width = width * ITEM_SIZE_MULT
+        height = height * ITEM_SIZE_MULT
     end
 
     return width, height
 end
 
 function TetrisItemData._calculateRangedWeaponSize(item)
-    local width = 4
-    local height = 2
+    local width = 2
+    local height = 1
 
     -- Read weight from the script item to easily ignore attachment weight
     local weight = item:getScriptItem():getActualWeight()
 
     if weight >= 2 then
+        width = 3
+        height = 1
+    end
+    if weight >= 3 then
+        width = 3
+        height = 2
+    end
+    if weight >= 4 then
+        width = 5
+        height = 2
+    end
+    if weight >= 5 then
         width = 6
         height = 2
     end
-    if weight >= 3 then
-        width = 6
-        height = 4
-    end
-    if weight >= 4 then
-        width = 10
-        height = 4
-    end
-    if weight >= 5 then
-        width = 12
-        height = 4
-    end
     if weight >= 6 then
-        width = 14
-        height = 4
+        width = 7
+        height = 2
+    end
+
+    if (SIZE_MULT_TOGGLE_TABLE["RangedWeapons"] == true) then
+        width = width * ITEM_SIZE_MULT
+        height = height * ITEM_SIZE_MULT
     end
 
     return width, height
 end
 
 function TetrisItemData._calculateMeleeWeaponSize(item)
-    local width = 2
-    local height = 2
+    local width = 1
+    local height = 1
 
     local weight = item:getActualWeight()
 
     if weight >= 0.5 then
+        width = 1
+        height = 2
+    end
+    if weight >= 1.6 then
+        width = 1
+        height = 3
+    end
+    if weight >= 2.5 then
+        width = 1
+        height = 4
+    end
+    if weight >= 3.5 then
         width = 2
         height = 4
     end
-    if weight >= 1.6 then
-        width = 2
-        height = 6
-    end
-    if weight >= 2.5 then
-        width = 2
-        height = 8
-    end
-    if weight >= 3.5 then
-        width = 4
-        height = 8
-    end
     if weight >= 4 then
-        width = 4
-        height = 10
+        width = 2
+        height = 5
+    end
+
+    if (SIZE_MULT_TOGGLE_TABLE["MeleeWeapons"] == true) then
+        width = width * ITEM_SIZE_MULT
+        height = height * ITEM_SIZE_MULT
     end
 
     return width, height
 end
 
 function TetrisItemData._calculateItemSizeClothing(item)
-    local width = 4
-    local height = 4
+    local width = 2
+    local height = 2
 
     -- This shouldn't happen, but just in case a mod does something weird
     if item:IsClothing() == false then
@@ -131,21 +186,26 @@ function TetrisItemData._calculateItemSizeClothing(item)
 
     local bulletDef = item:getBulletDefense()
     if bulletDef >= 50 then
-        width = 6
-        height = 6
+        width = 3
+        height = 3
     else
         -- Read weight from the script item to ignore wetness weight and the like
         local weight = item:getScriptItem():getActualWeight()
         if weight >= 3.0 then
-            width = 6
-            height = 6
+            width = 3
+            height = 3
         elseif weight <= 0.5 then
-            width = 2
-            height = 2
+            width = 1
+            height = 1
         elseif weight <= 1.0 then
-            width = 2
-            height = 4
+            width = 1
+            height = 2
         end
+    end
+
+    if (SIZE_MULT_TOGGLE_TABLE["Clothing"] == true) then
+        width = width * ITEM_SIZE_MULT
+        height = height * ITEM_SIZE_MULT
     end
 
     return width, height
@@ -169,17 +229,18 @@ end
 -- Returns dimensions for a container item based on the number of items it can hold
 -- Always returns a dimension that is >= innerSize
 function TetrisItemData._calculateContainerItemSizeFromInner(innerSize)
-    local MAX_ITEM_DIM = 24
+    local MAX_ITEM_DIM = (12 * ITEM_SIZE_MULT)
+    local MIN_ITEM_DIM = (1 * ITEM_SIZE_MULT)
     if innerSize > MAX_ITEM_DIM * MAX_ITEM_DIM then
         return MAX_ITEM_DIM, MAX_ITEM_DIM
     end
 
     local best = 99999999
-    local bestX = 2
-    local bestY = 2
+    local bestX = (1 * ITEM_SIZE_MULT)
+    local bestY = (1 * ITEM_SIZE_MULT)
 
-    for x = 2, MAX_ITEM_DIM do
-        for y = 2, MAX_ITEM_DIM do
+    for x = MIN_ITEM_DIM, MAX_ITEM_DIM do
+        for y = MIN_ITEM_DIM, MAX_ITEM_DIM do
             local result = x * y
             local diff = math.abs(result - innerSize) + math.abs(x - y) -- Encourage square shapes 
             if diff < best and result >= innerSize then
@@ -201,28 +262,33 @@ function TetrisItemData._calculateMiscSize(item)
 end
 
 function TetrisItemData._calculateItemSizeWeightBased(item)
-    local width = 2
-    local height = 2
+    local width = 1
+    local height = 1
 
     local weight = item:getActualWeight()
 
     if weight < 1 then
+        width = 1
+        height = 1
+    elseif weight < 2 then
+        width = 1
+        height = 2
+    elseif weight < 3 then
         width = 2
         height = 2
-    elseif weight < 2 then
-        width = 2
-        height = 4
-    elseif weight < 3 then
-        width = 4
-        height = 4
     elseif weight < 4 then
-        width = 4
-        height = 6
+        width = 2
+        height = 3
     elseif weight < 5 then
-        width = 6
-        height = 6
+        width = 3
+        height = 3
     else
         return TetrisContainerData._calculateDimensions(weight * 2, 2)
+    end
+
+    if (SIZE_MULT_TOGGLE_TABLE["WeightBased"] == true) then
+        width = width * ITEM_SIZE_MULT
+        height = height * ITEM_SIZE_MULT
     end
 
     return width, height
@@ -241,7 +307,7 @@ function TetrisItemData._calculateFluidContainerSize(item)
     -- Small containers are 1x1
     local fluidCapacity = fluidContainer:getCapacity()
     if fluidCapacity <= 0.5 then
-        return 2, 2
+        return (1 * ITEM_SIZE_MULT), (1 * ITEM_SIZE_MULT)
     end
 
     -- Everything else is 1 slot per liter with a minimum size of 1x2
@@ -260,32 +326,65 @@ function TetrisItemData._calculateItemSizeWeightBasedTall(item)
 end
 
 function TetrisItemData._calculateEntertainmentSize(item)
-    local width = 2
-    local height = 2
+    local width = 1
+    local height = 1
 
     local mediaData = item:getMediaData()
     if mediaData then
         local category = mediaData:getCategory()
         if category == "CDs" then
-            width = 2
-            height = 2
+            width = 1
+            height = 1
         end
+    end
+
+    if (SIZE_MULT_TOGGLE_TABLE["Entertainment"] == true) then
+        width = width * ITEM_SIZE_MULT
+        height = height * ITEM_SIZE_MULT
+    end
+
+    return width, height
+end
+
+function TetrisItemData._calculateBookSize(item)
+    local width = 1
+    local height = 1
+
+    local weight = item:getActualWeight()
+
+    if (SIZE_MULT_TOGGLE_TABLE["Books"] == true) then
+        width = width * ITEM_SIZE_MULT
+        height = height * ITEM_SIZE_MULT
+    end
+
+    return width, height
+end
+
+function TetrisItemData._calculateSeedSize(item)
+    local width = 1
+    local height = 1
+
+    local weight = item:getActualWeight()
+
+    if (SIZE_MULT_TOGGLE_TABLE["Seeds"] == true) then
+        width = width * ITEM_SIZE_MULT
+        height = height * ITEM_SIZE_MULT
     end
 
     return width, height
 end
 
 function TetrisItemData._calculateMoveableSize(item)
-    local width = 2
-    local height = 2
+    local width = 1
+    local height = 1
 
     local weight = item:getActualWeight()
     return TetrisContainerData._calculateDimensions(weight * 2, 2)
 end
 
 TetrisItemData._itemClassToSizeCalculation = {
-    [TetrisItemCategory.AMMO] = {x = 2, y = 2},
-    [TetrisItemCategory.BOOK] = {x = 2, y = 4},
+    [TetrisItemCategory.AMMO] = TetrisItemData._calculateAmmoSize,
+    [TetrisItemCategory.BOOK] = TetrisItemData._calculateBookSize,
     [TetrisItemCategory.CLOTHING] = TetrisItemData._calculateItemSizeClothing,
     [TetrisItemCategory.CONTAINER] = TetrisItemData._calculateItemSizeContainer,
     [TetrisItemCategory.ENTERTAINMENT] = TetrisItemData._calculateEntertainmentSize,
@@ -298,7 +397,7 @@ TetrisItemData._itemClassToSizeCalculation = {
     [TetrisItemCategory.MISC] = TetrisItemData._calculateMiscSize,
     [TetrisItemCategory.MOVEABLE] = TetrisItemData._calculateMoveableSize,
     [TetrisItemCategory.RANGED] = TetrisItemData._calculateRangedWeaponSize,
-    [TetrisItemCategory.SEED] = {x = 2, y = 2},
+    [TetrisItemCategory.SEED] = TetrisItemData._calculateSeedSize,
 }
 
 


### PR DESCRIPTION
All occurances of multiplying the width and heights have been reverted to defaults and replaced with multiplying them by a varaible ("ITEM_SIZE_MULT") for better ease of mantainability or later changes.

A table ("SIZE_MULT_TOGGLE_TABLE") has been added with each category of items as keys with boolean values which controls which will have the size multiplier applies in their calculations. Just as a nice to have, not really seeing it as important functionality.

A few categories have had functions added to calculate their tetris sizes for consistency and code readability. This allows further logic to be added later if desired based on those items properties like the others.

Item scale granularity has not yet been looked into.